### PR TITLE
HSEARCH-1182 @IndexedEmbedded filter composition: fix generation of object paths relative to filter

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/impl/ConfiguredIndexSchemaNestingContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/impl/ConfiguredIndexSchemaNestingContext.java
@@ -89,7 +89,7 @@ class ConfiguredIndexSchemaNestingContext implements IndexSchemaNestingContext {
 				String objectName = prefixToParse.substring( afterPreviousDotIndex, nextDotIndex );
 
 				// Make sure to mark the paths as encountered in the filter
-				String objectNameRelativeToFilter = prefixToParse.substring( 0, nextDotIndex );
+				String objectNameRelativeToFilter = prefixToParse.substring( unconsumedPrefix.length(), nextDotIndex );
 
 				// So that's as soon as excluded, right?
 				if ( !filter.isPathIncluded( objectNameRelativeToFilter ) ) {

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/validation/TestInvalidPaths.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/validation/TestInvalidPaths.java
@@ -56,7 +56,7 @@ public class TestInvalidPaths {
 					.hasMessageContainingAll(
 							"type '" + DeepPathWithLeadingPrefixCase.class.getName() + "'",
 							"Non-matching includePaths filters: [b.c.dne]",
-							"Encountered field paths: [notJustAb, b.c, b.c.indexed, b.c.notIndexed]"
+							"Encountered field paths: [b, b.c, b.c.indexed, b.c.notIndexed]"
 					);
 		}
 	}


### PR DESCRIPTION
The filter already prepends the unconsumed prefix, so we should not include it in the path passed to isPathIncluded()